### PR TITLE
feat: implement Root struct for safe file operations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/i9si-sistemas/safe-os
+
+go 1.24.1
+
+require github.com/i9si-sistemas/assert v0.0.0-20250430171352-359d1481c58c

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/i9si-sistemas/assert v0.0.0-20250430171352-359d1481c58c h1:8DlRk8oT2YFyo8MbY00ge2wEEGGLZWr2mGJextdSePI=
+github.com/i9si-sistemas/assert v0.0.0-20250430171352-359d1481c58c/go.mod h1:xRwY4u6NZZjNLlgdBSaNESQEUSJ4CxuT4lWQAbvwfBQ=

--- a/root.go
+++ b/root.go
@@ -1,0 +1,82 @@
+package safeos
+
+import (
+	"io"
+	"io/fs"
+	"os"
+)
+
+type Root struct {
+	Dir string
+}
+
+func (r *Root) CreateDir(dirname string) error {
+	root, err := r.init()
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+	return root.Mkdir(dirname, 0755)
+}
+
+func (r *Root) CreateFile(filePath string, data []byte) error {
+	root, err := r.init()
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+	file, err := root.Create(filePath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	_, err = file.Write(data)
+	return err
+}
+
+func (r *Root) ReadFile(filePath string) ([]byte,  error){
+	file, err := os.OpenInRoot(r.Dir, filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	return io.ReadAll(file)
+}
+
+func (r *Root) DeleteFile(filePath string) error {
+	root, err := r.init()
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+	return root.Remove(filePath)
+}
+
+func (r *Root) Delete() error {
+	return os.RemoveAll(r.Dir)
+}
+
+func (r *Root) FS() fs.FS {
+	root, err := r.init()
+	if err != nil {
+		return nil
+	}
+	return root.FS()
+}
+
+
+func (r *Root) Stat(filePath string) (os.FileInfo, error) {
+	root, err := r.init()
+	if err != nil {
+		return nil, err
+	}
+	defer root.Close()
+	return root.Stat(filePath)
+}
+
+func (r *Root) init() (*os.Root, error) {
+	if _, err := os.Stat(r.Dir); os.IsNotExist(err) {
+		_ = os.MkdirAll(r.Dir, 0755)
+	}
+	return os.OpenRoot(r.Dir)
+}

--- a/root_test.go
+++ b/root_test.go
@@ -1,0 +1,35 @@
+package safeos
+
+import (
+	"os"
+	"testing"
+
+	"github.com/i9si-sistemas/assert"
+)
+
+func TestSafeOS(t *testing.T) {
+	root := &Root{Dir: "./tmp"}
+	defer root.Delete()
+	assert.NoError(t, root.CreateDir("./safeos"))
+	publicFile := "./safeos/public.txt"
+	assert.NoError(t, root.CreateFile(publicFile, []byte("test")))
+	secretFile := "./secret.txt"
+	f, _ := os.Create(secretFile)
+	defer func(){
+		assert.NoError(t, f.Close())
+		assert.NoError(t, os.Remove(secretFile))
+	}()
+	assert.NotNil(t, f)
+	_, err := f.Write([]byte("secret"))
+	assert.NoError(t, err)
+	b, err  := root.ReadFile("../secret.txt")
+	assert.Empty(t, b)
+	assert.Error(t, err)
+	b, err = root.ReadFile(publicFile)
+	assert.NoError(t, err)
+	assert.Equal(t, string(b), "test")
+	assert.NoError(t, root.DeleteFile(publicFile))
+	fileInfo, err := root.Stat(publicFile)
+	assert.True(t, os.IsNotExist(err))
+	assert.Nil(t, fileInfo)
+}


### PR DESCRIPTION
This PR introduces the `Root` struct and its associated methods, providing a safer way to interact with the file system within a specified directory.

The `Root` struct encapsulates a directory path and offers methods for:

- Creating directories (`CreateDir`)
- Creating files (`CreateFile`)
- Reading files (`ReadFile`)
- Deleting files (`DeleteFile`)
- Deleting the entire root directory (`Delete`)
- Accessing the root as a `fs.FS` (`FS`)
- Getting file stats (`Stat`)

The `init` method ensures that the root directory exists before performing any operations. This approach enhances security by restricting file system access to the designated root directory.